### PR TITLE
Add timing information for all asserts.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,11 @@ Format inspired by WWW::Mechanize's revision log
 See GIT history for more detailed listing:
 https://github.com/jlavallee/tap-harness-junit.git
 
+0.36	TBD
+======================================
+[ENHANCEMENTS]
+Per-assert timing info is now much more accurate.
+
 0.35 	Wed Mar  2 21:05:13 2011 -0800
 ======================================
 [FIXES]


### PR DESCRIPTION
This is achieved by injecting our parser. When a result appears, it
persists it in the parser object and enriches it with timing information.
This way we can get rid of the inaccurate timing per assert hack, as well
as of the temporary TAP files in exchange for another invasive hack...

If parser callbacks were stackable, we could just register callbacks
before calling TAP::Harness::runtests, but they are not and if we did
register them, we could override user's callbacks and break compatibility
with TAP::Harness.
